### PR TITLE
Improved support for github private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ More: https://confluence.atlassian.com/pages/viewpage.action?pageId=271943168
 
 ## Usage
 * commit and push 
+## Common Issues
+
+### Not able to pull from a private github repository
+In order to be able to pull from a github repository, this script has to connect using a public key, you have to add the key to the .ssh folder of the user who is running the git-deploy script. And server has to trust on github authenticity without interactive prompt, you can fix this creating a .php file with this content and running only once, you should see a succesfully authentication message with some debug information.
+
+```php
+error_reporting(E_ALL);
+header('Content-type: text/plain');
+ini_set('display_errors',1);
+ini_set('display_startup_errors',1);
+echo system( 'ssh -v -o "StrictHostKeyChecking no" git@github.com 2>&1' );
+// Uncomment this lines to also check that pull is working
+//chdir('/path/to/repository/');
+//echo system('git pull origin master 2>&1'); // change master for your branch if needed
+```
 
 # More information
 http://lkwdwrd.com/git-auto-deployment/

--- a/deploy-config.php
+++ b/deploy-config.php
@@ -40,6 +40,7 @@ $repos = array(
  * Sets the deploy log directory
  */
 define( 'DEPLOY_LOG_DIR', dirname( __FILE__ ) );
+define( 'DEPLOY_FULL_OUTPUT', true );
 
 /* Do not edit below this line */
 require_once 'inc/class.deploy.php';

--- a/inc/class.deploy.php
+++ b/inc/class.deploy.php
@@ -212,6 +212,9 @@ abstract class Deploy {
 			// Update the local repository
 			exec( 'git pull ' . $this->_remote . ' ' . $this->_branch . ' 2>&1', $output, $return_var );
 
+			if ($return_var != 0)
+				throw new Exception("Git pull failed", 1);
+
 			// Secure the .git directory
 			echo exec( 'chmod -R og-rx .git' );
 
@@ -224,8 +227,10 @@ abstract class Deploy {
 
 			if (DEPLOY_FULL_OUTPUT)
 				$this->log( $output );
+
 		} catch ( Exception $e ) {
 			$this->log( $e, 'ERROR' );
+			$this->log( $output );
 		}
 	}
 }

--- a/inc/class.deploy.php
+++ b/inc/class.deploy.php
@@ -210,7 +210,7 @@ abstract class Deploy {
 			exec( 'git reset --hard HEAD', $output );
 
 			// Update the local repository
-			exec( 'git pull ' . $this->_remote . ' ' . $this->_branch, $output );
+			exec( 'git pull ' . $this->_remote . ' ' . $this->_branch . ' 2>&1', $output, $return_var );
 
 			// Secure the .git directory
 			echo exec( 'chmod -R og-rx .git' );
@@ -218,8 +218,12 @@ abstract class Deploy {
 			if ( is_callable( $this->_post_deploy ) )
 				call_user_func( $this->_post_deploy );
 
-			$this->log( '[SHA: ' . $this->_commit . '] Deployment of ' . $this->_name . ' from branch ' . $this->_branch . ' successful' );
-			echo( '[SHA: ' . $this->_commit . '] Deployment of ' . $this->_name . ' from branch ' . $this->_branch . ' successful' );
+			$log_msg = "[SHA: {$this->_commit} Deployment of {$this->_name} from branch {$this->_branch} successful".
+			$this->log( $log_msg );
+			echo $log_msg;
+
+			if (DEPLOY_FULL_OUTPUT)
+				$this->log( $output );
 		} catch ( Exception $e ) {
 			$this->log( $e, 'ERROR' );
 		}


### PR DESCRIPTION
The current version of git-deploy add a log entry with a message saying that git pull was succesfully even when git pull exited with an error code, showing no ouput as `exec` php method doesn't record the `STD_ERR` output.

This MR fix that issue, raising an exception and adding git error into log. This also adds a new option to log full git output if required.

Last, the README.md contains instructions to make the user who is running the script (apache most of the cases) to trust the identity of github.com, wihtout this, is impossible to pull from a private repo on github.
